### PR TITLE
Remove all 401 HTTP Status code

### DIFF
--- a/prestapyt/prestapyt.py
+++ b/prestapyt/prestapyt.py
@@ -99,7 +99,8 @@ class PrestaShopWebService(object):
         # use header you coders you want, otherwise, use a default
         self.headers = headers
         if self.headers is None:
-            self.headers = {'User-agent': 'Prestapyt: Python Prestashop Library', 'Authorization': 'Basic {0}'.format(base64.b64encode('{0}:{1}'.format(self._api_key, '')))}
+            self.headers = {'User-agent': 'Prestapyt: Python Prestashop Library', 
+                            'Authorization': 'Basic {0}'.format(base64.b64encode('{0}:{1}'.format(self._api_key, '')))}
 
         # init http client in the init for re-use the same connection for all call
         self.client = httplib2.Http(**self.client_args)


### PR DESCRIPTION
With actual code, each api call generate 2 requests :
- first return "401 Unauthorized"
- second is the good request

This pull request allow to call the api with only one request by forcing to send authentification. Prestashop doesn't allow to call api without authentification, thus send automaticaly authentification is safe.

2 avantages :
- remove all 401 request in the web server's log
- reduce the number of request, thus the call will be faster

The http client is created in the **init** (https://github.com/leblanc-simon/prestapyt/blob/master/prestapyt/prestapyt.py#L106) to create only one httplib2.Http object for one PrestaShopWebService object :
- less code to execute if you call _execute more than once
- reuse the same connection for all call to _execute
